### PR TITLE
mergiraf: Add version 0.2.0

### DIFF
--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.2.0",
+    "description": "A syntax-aware git merge driver for a growing collection of programming languages and file formats.",
+    "homepage": "https://mergiraf.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "hash": "b3205197942bfec67b07b36532972196407db26095641a61fcb1b2bf698966c0",
+            "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.2.0/mergiraf_x86_64-pc-windows-gnu.zip"
+        }
+    },
+    "bin": "mergiraf.exe",
+    "checkver": {
+        "url": "https://codeberg.org/api/v1/repos/mergiraf/mergiraf/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v$version/mergiraf_x86_64-pc-windows-gnu.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add mergiraf: A syntax-aware git merge driver for a growing collection of programming languages and file formats.

https://mergiraf.org/

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
